### PR TITLE
Handle request errors better

### DIFF
--- a/src/PagerDuty.coffee
+++ b/src/PagerDuty.coffee
@@ -41,10 +41,10 @@ class PagerDuty
       uri: 'https://events.pagerduty.com/generic/2010-04-15/create_event.json'
       json: json
     , (err, response, body) ->
-      if err or response.statusCode != 200
-        callback err || new Error(body.errors[0])
-      else
-        callback null, body
-
-
-
+      if err?
+        return callback err
+      if response.statusCode != 200
+        if body.errors?
+          return callback new Error body.errors
+        return callback new Error "Status code #{response.statusCode} from request to PagerDuty API. Body: #{JSON.stringify(body)}"
+      callback null, body


### PR DESCRIPTION
Previously, we assume that errors exists and has at least one element. This isn't always true, and leads to an uncaught exception: https://github.com/skomski/node-pagerduty/issues/8. The uncaught exception is causing alertbot to die unexpectedly.

I decided to fork this library to fix the issue since:
* It doesn't seem to be regularly maintained anymore as the last commit was 2 years ago, so we won't need to do work to keep our fork up to date.
* Aside from the bug, the library works for us, so there's no reason to replace it.
* I didn't find any obviously superior replacements, and the other libraries also don't get updated frequently.